### PR TITLE
android: Exclude dependenciesInfo from APKs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,6 +39,15 @@ android {
     buildFeatures {
         compose = true
     }
+
+    dependenciesInfo {
+        // Exclude dependency block from APKs for open source compliance.
+        // @see https://android.izzysoft.de/articles/named/iod-scan-apkchecks#blobs
+        includeInApk = false
+        // Include dependency block in AAB for playstore compliance.
+        // @see https://developer.android.com/build/dependencies#dependency-info-play
+        includeInBundle = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Resolves #9 

Before:
1. APKs had obscured/signed dependencies info

After:
1. APKs don't have dependencies info 

Context:
1. Dependencies info cannot be read and inspected for malware.

Test:
1. Successful build
    1. Android Studio -> Build -> Build App Bundle(s) / APK(s):
        1. Build APK(s)
        2. Build Bundle(s)
    1. Ensure both are successful
1. Release doesn't have dependencies block
    1. Android Studio -> Build -> Generate Signed APK -> release
    1. Run the following script:
        ```bash
        # clone containerized tools
        git clone https://github.com/nizarmah/droidkit
        cd ./droidkit
        
        # copy the app release
        cp /.../igatha/android/app/release/app-release.apk ./data/.
        
        # check for dependency block
        docker compose run --rm apksigtool \
            parse --json ./data/app-release.apk \
            | jq -r ".pairs[].value._type"
        ```