### PR TITLE
feat: add Themed Icon support

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for Android's Themed Launcher Icons feature introduced in [Android 13](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

Examples:

- Dark Theme, Coral palette

![igatha_themed_dark](https://github.com/user-attachments/assets/f1ae44cf-8562-4085-b4d3-7c025479c095)

- Light Theme, Coral palette

![igatha_themed_light](https://github.com/user-attachments/assets/4ae89e11-aeb6-4205-9c96-535633942a98)